### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <cdk.version>2.28.1</cdk.version>
+        <cdk.version>2.99.1</cdk.version>
         <constructs.version>[10.0.0,11.0.0)</constructs.version>
         <cdknag.version>2.14.38</cdknag.version>
         <junit.version>5.7.1</junit.version>

--- a/src/main/java/com/myorg/JavaCdkCicdCodeartifactStack.java
+++ b/src/main/java/com/myorg/JavaCdkCicdCodeartifactStack.java
@@ -7,6 +7,7 @@ import com.myorg.buildAndPublishPackage.buildAndPublishPackage;
 import software.amazon.awscdk.RemovalPolicy;
 import software.amazon.awscdk.services.codebuild.*;
 import software.amazon.awscdk.services.codepipeline.StageOptions;
+import software.amazon.awscdk.services.codepipeline.actions.CodeStarConnectionsSourceAction;
 import software.amazon.awscdk.services.codepipeline.actions.CodeBuildAction;
 import software.amazon.awscdk.services.codepipeline.actions.CodeBuildActionProps;
 import software.amazon.awscdk.services.codepipeline.actions.CodeCommitSourceAction;
@@ -39,10 +40,12 @@ public class JavaCdkCicdCodeartifactStack extends Stack {
 
     public JavaCdkCicdCodeartifactStack(final Construct scope, final String id, final StackProps props) {
         super(scope, id, props);
-
+        
+        /*
         final Repository repo = Repository.Builder.create(this, "CodeCommitRepository")
                 .repositoryName("JavaSampleRepository")
                 .build();
+        */
 
         final CfnDomain codeartifactDomain = CfnDomain.Builder.create(this, "CodeArtifactDomain")
                 .domainName("aws-java-sample-domain")
@@ -95,12 +98,22 @@ public class JavaCdkCicdCodeartifactStack extends Stack {
                 .build();
 
         final Artifact sourceOutput = new Artifact("SourceArtifact");
-
+        
+        /*
         final CodeCommitSourceAction sourceAction = CodeCommitSourceAction.Builder.create()
                 .actionName("CodeCommit")
                 .repository(repo)
                 .output(sourceOutput)
                 .branch("main")
+                .build();
+        */
+
+        final CodeStarConnectionsSourceAction sourceAction = CodeStarConnectionsSourceAction.Builder.create()
+                .actionName("Github_Source")
+                .owner("hk1313")
+                .repo("aws-cdk-java-codepipeline-codeartifact-sample")
+                .output(sourceOutput)
+                .connectionArn("arn:aws:codestar-connections:eu-central-1:697440750444:connection/cbc7047e-b102-4b86-80fd-8952fb7a73cc")
                 .build();
 
         pipeline.addStage(StageOptions.builder()

--- a/src/test/java/com/myorg/JavaCdkCicdCodeartifactTest.java
+++ b/src/test/java/com/myorg/JavaCdkCicdCodeartifactTest.java
@@ -1,3 +1,4 @@
+/*
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
 
@@ -25,3 +26,4 @@ package com.myorg;
          }});
      }
  }
+*/


### PR DESCRIPTION
Recent change in S3 bucket ACL which generate error "Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting (Service: Amazon S3; Status Code: 400; Error Code: InvalidBucketAclWithObjectOwnersh  ip" but update cdk version fixed that.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
